### PR TITLE
Fix dyes

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -7,7 +7,7 @@ codechickenlib.version=1.1.3.140
 codechickencore.version=1.0.7.47
 nei.version=1.0.5.120
 gregtech.jenkinsbuild=63
-gregtech.version=5.09.32.29
+gregtech.version=5.09.32.31
 cofhcore.version=[1.7.10]3.1.4-329-dev
 cofhlib.version=[1.7.10]1.0.3-175-dev
 

--- a/src/main/java/com/github/technus/tectech/loader/MainLoader.java
+++ b/src/main/java/com/github/technus/tectech/loader/MainLoader.java
@@ -64,16 +64,6 @@ public final class MainLoader {
     }
 
     public static void preLoad(){
-        //Set proper values in gt arrays
-        dyeLightBlue.mRGBa[0]=96;
-        dyeLightBlue.mRGBa[1]=128;
-        dyeLightBlue.mRGBa[2]=255;
-        dyeBlue.mRGBa[0]=0;
-        dyeBlue.mRGBa[1]=32;
-        dyeBlue.mRGBa[2]=255;
-        MACHINE_METAL.mRGBa[0]=210;
-        MACHINE_METAL.mRGBa[1]=220;
-        MACHINE_METAL.mRGBa[2]=255;
 
         //set expanded texture arrays for tiers
         try {


### PR DESCRIPTION
This fix will stop TecTech from modifying the GregTech Dyes enum, and update to the latest version of GT5U.