### PR TITLE
add check only block without meta

### DIFF
--- a/src/main/java/com/github/technus/tectech/mechanics/structure/StructureUtility.java
+++ b/src/main/java/com/github/technus/tectech/mechanics/structure/StructureUtility.java
@@ -391,6 +391,7 @@ public class StructureUtility {
                 @Override
                 public boolean check(T t, World world, int x, int y, int z) {
                     Block worldBlock = world.getBlock(x, y, z);
+                    if (meta == -1) return block == worldBlock;
                     return block == worldBlock && meta == worldBlock.getDamageValue(world, x, y, z);
                 }
 
@@ -411,6 +412,7 @@ public class StructureUtility {
                 @Override
                 public boolean check(T t, World world, int x, int y, int z) {
                     Block worldBlock = world.getBlock(x, y, z);
+                    if (meta == -1) return block == worldBlock;
                     return block == worldBlock && meta == worldBlock.getDamageValue(world, x, y, z);
                 }
 
@@ -431,6 +433,10 @@ public class StructureUtility {
 
     public static <T> IStructureElement<T> ofBlock(Block block, int meta) {
         return ofBlock(block, meta, block, meta);
+    }
+    
+    public static <T> IStructureElement<T> ofBlock(Block block) {
+        return ofBlock(block, -1, block, 0);
     }
 
     //endregion


### PR DESCRIPTION
Meta 0 will be used to build and display the hologram.
For example, you can make 16 kinds of glass blocks, and check only the block, without meta.